### PR TITLE
Clarity around config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Remember to configure the plugin in config.json in your home directory inside th
 + "onValue": "OPTIONALLY PUT THE VALUE THAT MEANS ON HERE (DEFAULT true)",
 + "offValue": "OPTIONALLY PUT THE VALUE THAT MEANS OFF HERE (DEFAULT false)",
 + "statusCmd": "OPTIONALLY PUT THE STATUS COMMAND HERE" 
-+ "integerValue": "OPTIONALLY SET THIS TRUE TO USE 1/0 AS VALUES"
++ "integerValue": "OPTIONALLY INCLUDE THIS TO USE 1/0 AS VALUES"
+
+Note that if set, integerValue will override both onValue and offValue.
 
 Look for a sample config in [config.json example](https://github.com/ilcato/homebridge-mqttswitch/blob/master/config.json)

--- a/config.json
+++ b/config.json
@@ -1,32 +1,29 @@
 {
-    "bridge": {
-        "name": "Homebridge",
-        "username": "CC:22:3D:E3:CE:30",
-        "port": 51826,
-        "pin": "031-45-154"
-    },
-    
-    "description": "This is an example configuration file. You can use this as a template for creating your own configuration file.",
+  "bridge": {
+    "name": "Homebridge",
+    "username": "CC:22:3D:E3:CE:30",
+    "port": 51826,
+    "pin": "031-45-154"
+  },
+  
+  "description": "This is an example configuration file. You can use this as a template for creating your own configuration file.",
+ 
+ "platforms": [],
 
-    "platforms": [
-    ],
-    "accessories": [
-    	{
-        	"accessory": "mqttswitch",
-            "name": "PUT THE NAME OF YOUR SWITCH HERE",
-            "url": "PUT URL OF THE BROKER HERE",
-			"username": "PUT USERNAME OF THE BROKER HERE",
-            		"password": "PUT PASSWORD OF THE BROKER HERE",
- 			"caption": "PUT THE LABEL OF YOUR SWITCH HERE",
- 			"topics": {
- 				"statusGet": 	"PUT THE MQTT TOPIC FOR THE GETTING THE STATUS OF YOUR SWITCH HERE",
- 				"statusSet": 	"PUT THE MQTT TOPIC FOR THE SETTING THE STATUS OF YOUR SWITCH HERE"
- 			},
-			"onValue": "OPTIONALLY PUT THE VALUE THAT MEANS ON HERE (DEFAULT true)",
-			"offValue": "OPTIONALLY PUT THE VALUE THAT MEANS OFF HERE (DEFAULT false)",
-                        "statusCmd": "OPTIONALLY PUT THE STATUS COMMAND HERE",
-		    "integerValue": "OPTIONALLY SET THIS TRUE TO USE 1/0 AS VALUES"
- 			
-    	}
-    ]
+ "accessories": [
+    {
+      "accessory": "mqttswitch",
+      "name": "Desk Lamp",
+      "url": "mqtt://mqtt-server",
+      "username": "user",
+      "password": "pass",
+      "caption": "Office Light",
+      "topics": {
+        "statusGet": "stat/shelf/POWER",
+        "statusSet": "cmnd/shelf/power"
+      },
+      "onValue": "ON",
+      "offValue": "OFF"
+    }
+  ]
 }


### PR DESCRIPTION
Hi,

I've made a small change to the README and supplied a more real-world config.json example. It took me a while to get things going without this, due to a couple of reasons:

1. I didn't know to start with that the broker URL was mqtt://server
2. In my config, integerValue was set to 'false' but code is simply checking it's defined.

Cheers, James